### PR TITLE
chore(ci): add typechecking to CI flow

### DIFF
--- a/.github/workflows/backend-lint.yml
+++ b/.github/workflows/backend-lint.yml
@@ -21,5 +21,8 @@ jobs:
       - name: Install dependencies
         run: bun install
 
+      - name: Run typecheck
+        run: bun run typecheck
+
       - name: Run ESLint & Prettier
         run: bun run lint

--- a/backend/package.json
+++ b/backend/package.json
@@ -8,6 +8,7 @@
     "start": "NODE_ENV=production bun src/server.ts",
     "build": "bun build src/server.ts --outdir ./dist --target bun",
     "start:built": "NODE_ENV=production bun dist/server.js",
+    "typecheck": "tsc --noEmit",
     "lint": "eslint . --config src/eslint.config.ts && prettier . --check",
     "lint:fix": "eslint . --config src/eslint.config.ts --fix && prettier . --write"
   },


### PR DESCRIPTION
# Description

We want to run `tsc` on our PRs so we don't introduce type errors by accident.

This is going to fail as of making the PR since there are active issues