### PR TITLE
Fix Updated Migrations to Include New lastQuickBooksImportTime time

### DIFF
--- a/backend/src/migrations/1758515207728-fix-company-last-quick-books-import-time.ts
+++ b/backend/src/migrations/1758515207728-fix-company-last-quick-books-import-time.ts
@@ -1,0 +1,15 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class FixCompanyLastQuickBooksImportTime1758515207728 implements MigrationInterface {
+    name = "FixCompanyLastQuickBooksImportTime1758515207728";
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "company" DROP COLUMN "lastQuickBooksImportTime"`);
+        await queryRunner.query(`ALTER TABLE "company" ADD "lastQuickBooksImportTime" TIMESTAMP WITH TIME ZONE`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "company" DROP COLUMN "lastQuickBooksImportTime"`);
+        await queryRunner.query(`ALTER TABLE "company" ADD "lastQuickBooksImportTime" TIMESTAMP`);
+    }
+}


### PR DESCRIPTION
# Description

- Added migrations that were seemingly omitted from another PR to avoid pollution of migrations in the future 

# Checklist

- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] New and existing unit tests pass locally with my changes

