### PR TITLE
Fixing Migration to remove Duplicate Create Table

### DIFF
--- a/backend/src/migrations/1758197300543-add-location-addresses.ts
+++ b/backend/src/migrations/1758197300543-add-location-addresses.ts
@@ -5,15 +5,11 @@ export class AddLocationAddresses1758197300543 implements MigrationInterface {
 
     public async up(queryRunner: QueryRunner): Promise<void> {
         await queryRunner.query(
-            `CREATE TABLE "user" ("id" uuid NOT NULL DEFAULT uuid_generate_v4(), "firstName" character varying NOT NULL, "lastName" character varying NOT NULL, "email" character varying, CONSTRAINT "PK_cace4a159ff9f2512dd42373760" PRIMARY KEY ("id"))`
-        );
-        await queryRunner.query(
             `CREATE TABLE "location_address" ("id" uuid NOT NULL DEFAULT uuid_generate_v4(), "country" character varying NOT NULL, "stateProvince" character varying NOT NULL, "city" character varying NOT NULL, "streetAddress" character varying NOT NULL, "postalCode" integer NOT NULL, "county" character varying, CONSTRAINT "PK_bf1188fd425a5c4f19d6fa22c2e" PRIMARY KEY ("id"))`
         );
     }
 
     public async down(queryRunner: QueryRunner): Promise<void> {
         await queryRunner.query(`DROP TABLE "location_address"`);
-        await queryRunner.query(`DROP TABLE "user"`);
     }
 }


### PR DESCRIPTION
# Description

The migration file was generated with an extra CREATE TABLE line for the users table, meaning that it was probably generated off of a local db that wasn't fully migrated. Manually fixed the migration file so that it is runnable in series with the others. 

Could be a sign to improve our migration generation workflow (maybe we have migrations be generated off of prod??)

Also I ran the fixed migration on prod already to create the new table

# Backend PRs:

- [x] I updated relevant API documentation and tests

# Frontend PRs:

Page route(and description of how to get desired flow if necessary)

Please include any relevant images of the changes here.

# Did any new/other issues pop up?

No

# Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes

