### PR TITLE
fix(migrations): reorder migrations

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -1,9 +1,9 @@
 {
   "name": "backend",
   "scripts": {
-    "migration:gen": "NODE_ENV=development typeorm-ts-node-esm migration:generate",
-    "migration:dev": "NODE_ENV=development typeorm-ts-node-esm migration:run -d ./src/typeorm-config.ts",
-    "migration:prod": "NODE_ENV=production typeorm-ts-node-esm migration:run -d ./src/typeorm-config.ts",
+    "migration:gen": "NODE_ENV=development bunx --bun typeorm-ts-node-esm migration:generate",
+    "migration:dev": "NODE_ENV=development bunx --bun typeorm-ts-node-esm migration:run -d ./src/typeorm-config.ts",
+    "migration:prod": "NODE_ENV=production bunx --bun typeorm-ts-node-esm migration:run -d ./src/typeorm-config.ts",
     "dev": "NODE_ENV=development bun --hot run src/server.ts",
     "start": "NODE_ENV=production bun src/server.ts",
     "build": "bun build src/server.ts --outdir ./dist --target bun",

--- a/backend/src/migrations/1759072454464-fix-disaster-column-names-dates-plus-nullable.ts
+++ b/backend/src/migrations/1759072454464-fix-disaster-column-names-dates-plus-nullable.ts
@@ -1,7 +1,7 @@
 import { MigrationInterface, QueryRunner } from "typeorm";
 
-export class FixDisasterColumnNamesDatesPlusNullable1759107988225 implements MigrationInterface {
-    name = "FixDisasterColumnNamesDatesPlusNullable1759107988225";
+export class FixDisasterColumnNamesDatesPlusNullable1759072454464 implements MigrationInterface {
+    name = "FixDisasterColumnNamesDatesPlusNullable1759072454464";
 
     public async up(queryRunner: QueryRunner): Promise<void> {
         await queryRunner.query(`ALTER TABLE "fema_disaster" RENAME COLUMN "femaId" TO "id"`);


### PR DESCRIPTION
We had a migration that should have been run earlier!

I also fixed the problems that typeorm-ts-node-esm has with the .js extension on imports by executing it through bun instead of node