### PR TITLE
Temporary FEMA fetching testing fix

### DIFF
--- a/backend/src/tests/femaFetching/create.test.ts
+++ b/backend/src/tests/femaFetching/create.test.ts
@@ -22,27 +22,31 @@ describe("Test Fetching Disasters", () => {
         backup.restore();
     });
 
-    it("should load a three pre-load three months of disaster data", async () => {
-        const femaService = new FemaService(dataSource);
+    // TODO: make a proper mock FEMA client to handle these tests.
+    // it("should load a three pre-load one week of disaster data", async () => {
+    //     const femaService = new FemaService(dataSource);
 
-        const threeMonthsAgo = new Date();
-        threeMonthsAgo.setMonth(threeMonthsAgo.getMonth() - 3);
-        await femaService.fetchFemaDisasters({ lastRefreshDate: threeMonthsAgo });
+    //     const oneWeekAgo = new Date();
+    //     oneWeekAgo.setDate(oneWeekAgo.getDate() - 7);
+    //     oneWeekAgo.setHours(0, 0, 0, 0);
+    //     await femaService.fetchFemaDisasters({ lastRefreshDate: oneWeekAgo });
 
-        const response = await app.request("/disaster", {
-            method: "GET",
-        });
-        const responseBody = await response.json();
-        expect(Array.isArray(responseBody)).toBe(true);
+    //     const response = await app.request("/disaster", {
+    //         method: "GET",
+    //     });
+    //     const responseBody = await response.json();
+    //     expect(Array.isArray(responseBody)).toBe(true);
 
-        const disasters = GetAllDisastersResponseSchema.parse(responseBody);
-        expect(disasters.length).toBeGreaterThanOrEqual(1);
-        const cutoff = threeMonthsAgo.getTime();
-        for (const disaster of disasters) {
-            expect(new Date(disaster.declarationDate).getTime()).toBeGreaterThanOrEqual(cutoff);
-            expect(disaster.designatedIncidentTypes).not.toBeNull();
-        }
-    });
+    //     const disasters = GetAllDisastersResponseSchema.parse(responseBody);
+    //     expect(disasters.length).toBeGreaterThanOrEqual(1);
+    //     const cutoff = oneWeekAgo.getTime();
+    //     for (const disaster of disasters) {
+    //         expect(new Date(disaster.declarationDate).getTime()).toBeGreaterThanOrEqual(cutoff);
+    //         // NOTE: This test potentially fails because we are fetching all FEMA disasters that were __refreshed__ in the last
+    //         // week, so they will not necessarily have been declared in the past week.
+    //         expect(disaster.designatedIncidentTypes).not.toBeNull();
+    //     }
+    // });
 
     it("should not add any duplicate disasters with the same id", async () => {
         const femaService = new FemaService(dataSource);


### PR DESCRIPTION
…r testing eventually

# Description

FEMA tests were broken because they were actually hitting the FEMA api and the fetched disasters are refreshed in that time span but not necessarily declared in tha ttime span. So down the road we will need to make an actual mock FEMA api client.

